### PR TITLE
Fixing race condition with sending email address to AdRoll.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -79,7 +79,10 @@ AdRoll.prototype.page = function(page) {
  */
 
 AdRoll.prototype.identify = function(identify) {
-  if (identify.email()) window.adroll_email = identify.email();
+  if (identify.email()) {
+    window.adroll_email = identify.email();
+    window.__adroll.record_adroll_email('segment');
+  }
 };
 
 /**

--- a/test/common.test.js
+++ b/test/common.test.js
@@ -112,9 +112,14 @@ each([1, 2], function(version) {
       });
 
       describe('#identify', function() {
+        beforeEach(function() {
+          analytics.stub(window.__adroll, 'record_adroll_email');
+        });
+
         it('should pass email', function() {
           analytics.identify('id', { email: 'test@email.com' });
           analytics.equal('test@email.com', window.adroll_email);
+          analytics.calledOnce(window.__adroll.record_adroll_email);
         });
 
         it('should not pass empty email', function() {


### PR DESCRIPTION
Currently `window.adroll_email` is set **after** the AdRoll pixel
checks for it. This change calls a function that explicitly
tracks the email value regardless of timing. Also passing 'segment'
as the source of the email value.
