### PR TITLE
refactor, clean up dupe properties, update semantic props

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -93,37 +93,110 @@ AdRoll.prototype.identify = function(identify) {
  */
 
 AdRoll.prototype.track = function(track) {
-  var event = track.event();
-  var events = this.events(event);
+  var events = this.events(track.event());
   var userId = this.analytics.user().id();
-
-  // TODO: Does this screw up subobjects?
-  // TODO: How does AdRoll handle nested objects?
-  var data = foldl(function(props, val, key) {
-    props[snake(key)] = val;
-    return props;
-  }, track.properties({
-    revenue: 'adroll_conversion_value_in_dollars',
-    total: 'adroll_conversion_value_in_dollars',
-    orderId: 'order_id',
-    id: 'product_id'
-  }));
-
-  if (userId) data.user_id = userId;
-
+  var data = formulateData(track);
   // As of April 2015, Adroll no longer accepts segments by name, instead
   // segmenting exclusively by segment ID, which will be present in events map
-  //
   // TODO: Deprecate and remove this behavior
   if (this.options._version === 1) {
     // If this is an unmapped event, fall back on a snakeized event name
-    if (!events.length) events = [event];
+    if (!events.length) events = [track.event()];
     // legacy (v1) behavior is to snakeize all mapped `events` values
     events = map(snake, events);
   }
 
+  if (userId) data.user_id = userId;
+
+  sendConversion(events, data);
+};
+
+/**
+ * Viewed/Added Product
+ *
+ * @api public
+ * @param {Track} track
+ */
+
+AdRoll.prototype.viewedProduct = AdRoll.prototype.addedProduct = function(track) {
+  var events = this.events(track.event());
+  var userId = this.analytics.user().id();
+  var data = formulateData(track, {
+    revenue: 'adroll_conversion_value',
+    id: 'product_id'
+  });
+
+  if (this.options._version === 1) {
+    // If this is an unmapped event, fall back on a snakeized event name
+    if (!events.length) events = [track.event()];
+    // legacy (v1) behavior is to snakeize all mapped `events` values
+    events = map(snake, events);
+  }
+
+  if (userId) data.user_id = userId;
+
+  sendConversion(events, data);
+};
+
+/**
+ * Completed Order
+ *
+ * @api public
+ * @param {Track} track
+ */
+
+AdRoll.prototype.completedOrder = function(track) {
+  var events = this.events(track.event());
+  var userId = this.analytics.user().id();
+  var data = formulateData(track, {
+    id: 'order_id',
+    revenue: 'adroll_conversion_value'
+  });
+
+  if (track.properties().currency) {
+    data.adroll_currency = track.properties().currency;
+    delete data.currency;
+  }
+
+  if (this.options._version === 1) {
+    // If this is an unmapped event, fall back on a snakeized event name
+    if (!events.length) events = [track.event()];
+    // legacy (v1) behavior is to snakeize all mapped `events` values
+    events = map(snake, events);
+  }
+
+  if (userId) data.user_id = userId;
+
+  sendConversion(events, data);
+};
+
+/**
+ * Send conversion events
+ *
+ * @params {Object, Object} events, data
+ * @api private
+ */
+
+function sendConversion(events, data) {
   each(events, function(segmentId) {
     data.adroll_segments = segmentId;
     window.__adroll.record_user(data);
   });
-};
+}
+
+/**
+ * Format data payload
+ *
+ * @params {Object, Object} track, alias
+ * @api private
+ */
+
+function formulateData(track, alias) {
+  var aliases = alias || {};
+  var ret = foldl(function(props, val, key) {
+    props[snake(key)] = val;
+    return props;
+  }, track.properties(aliases));
+
+  return ret;
+}

--- a/test/common.test.js
+++ b/test/common.test.js
@@ -18,7 +18,7 @@ each([1, 2], function(version) {
       events: {
         'Viewed Home Page': 'viewed_home_page',
         'Viewed Home Index Page': 'viewed_home_index_page',
-        'Order Created': 'order_created'
+        'Completed Order': 'order_created'
       }
     };
 
@@ -135,42 +135,51 @@ each([1, 2], function(version) {
 
         it('should include userId', function() {
           analytics.user().identify('id');
-          analytics.track('Order Created', {});
-          analytics.called(window.__adroll.record_user, {
+          analytics.track('Completed Order', {});
+          analytics.calledOnce(window.__adroll.record_user, {
             adroll_segments: 'order_created',
             user_id: 'id'
           });
         });
 
         it('should include orderId', function() {
-          analytics.track('Order Created', { orderId: 1 });
-          analytics.called(window.__adroll.record_user, {
+          analytics.track('Completed Order', { id: 1 });
+          analytics.calledOnce(window.__adroll.record_user, {
             adroll_segments: 'order_created',
             order_id: 1
           });
         });
 
         it('should map revenue to conversion_value', function() {
-          analytics.track('Order Created', { total: 1.99 });
-          analytics.called(window.__adroll.record_user, {
+          analytics.track('Completed Order', { revenue: 1.99 });
+          analytics.calledOnce(window.__adroll.record_user, {
             adroll_segments: 'order_created',
-            adroll_conversion_value_in_dollars: 1.99
+            adroll_conversion_value: 1.99
           });
         });
 
-        it('should map revenue as conversion_value', function() {
-          analytics.track('Order Created', { revenue: 2.99 });
-          analytics.called(window.__adroll.record_user, {
+        it('should should send total if no revenue for conversion_value', function() {
+          analytics.track('Completed Order', { total: 29.88 });
+          analytics.calledOnce(window.__adroll.record_user, {
             adroll_segments: 'order_created',
-            adroll_conversion_value_in_dollars: 2.99
+            adroll_conversion_value: 29.88
+          });
+        });
+
+        it('should map revenue as conversion_value and total as custom prop', function() {
+          analytics.track('Completed Order', { revenue: 2.99, total: 17.38 });
+          analytics.calledOnce(window.__adroll.record_user, {
+            adroll_segments: 'order_created',
+            adroll_conversion_value: 2.99,
+            total: 17.38
           });
         });
 
         it('should include properties', function() {
-          analytics.track('Order Created', { revenue: 2.99, id: '12345', sku: '43434-21', other: '1234' });
-          analytics.called(window.__adroll.record_user, {
+          analytics.track('Completed Order', { revenue: 2.99, id: '12345', sku: '43434-21', other: '1234' });
+          analytics.calledOnce(window.__adroll.record_user, {
             adroll_segments: 'order_created',
-            adroll_conversion_value_in_dollars: 2.99,
+            adroll_conversion_value: 2.99,
             product_id: '12345',
             sku: '43434-21',
             other: '1234',

--- a/test/v2.test.js
+++ b/test/v2.test.js
@@ -15,7 +15,7 @@ describe('AdRoll - v2', function() {
     events: {
       'Viewed Home Page': 'zi2b9e01',
       'Viewed Home Index Page': 'Jxp3fGpw',
-      'Order Created': 'f21vVsxY'
+      'Completed Order': 'f21vVsxY'
     }
   };
 
@@ -102,10 +102,19 @@ describe('AdRoll - v2', function() {
       });
 
       it('should send a mapped event', function() {
-        analytics.track('Order Created', { total: 1.99 });
+        analytics.track('Completed Order', { revenue: 17.38 });
         analytics.called(window.__adroll.record_user, {
           adroll_segments: 'f21vVsxY',
-          adroll_conversion_value_in_dollars: 1.99
+          adroll_conversion_value: 17.38
+        });
+      });
+
+      it('should map currency', function() {
+        analytics.track('Completed Order', { revenue: 17.38, currency: 'CAD' });
+        analytics.called(window.__adroll.record_user, {
+          adroll_segments: 'f21vVsxY',
+          adroll_conversion_value: 17.38,
+          adroll_currency: 'CAD'
         });
       });
 


### PR DESCRIPTION
This PR will separate some semantic ecommerce events into its own functions. Previously we were catching all `.track()` events under one function and was not really done cleanly.

I've refactored a lot here with @sperand-io's guidance. Some issues that the previous implementation had was that it would send duplicate values for adroll properties such as `product_id` and `order_id`. The new PR will no longer do that since it catches `Completed Order` and product events separately.

This PR also implements AdRoll's newest semantic properties such as `adroll_currency` and `adroll_conversion_value`

@segment-integrations/core 
Will fix #4 
