### PR TITLE
fix tests and semantic property lookup

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -122,8 +122,8 @@ AdRoll.prototype.viewedProduct = AdRoll.prototype.addedProduct = function(track)
   var events = this.events(track.event());
   var userId = this.analytics.user().id();
   var data = formulateData(track, {
-    revenue: 'adroll_conversion_value',
-    id: 'product_id'
+    id: 'product_id',
+    price: 'adroll_conversion_value'
   });
 
   if (this.options._version === 1) {
@@ -149,7 +149,7 @@ AdRoll.prototype.completedOrder = function(track) {
   var events = this.events(track.event());
   var userId = this.analytics.user().id();
   var data = formulateData(track, {
-    id: 'order_id',
+    orderId: 'order_id',
     revenue: 'adroll_conversion_value'
   });
 

--- a/test/common.test.js
+++ b/test/common.test.js
@@ -122,7 +122,8 @@ each([1, 2], function(version) {
         it('should pass email', function() {
           analytics.identify('id', { email: 'test@email.com' });
           analytics.equal('test@email.com', window.adroll_email);
-          analytics.called(window.__adroll.record_adroll_email);
+          analytics.called(window.__adroll.record_adroll_email, 'segment');
+          analytics.calledOnce(window.__adroll.record_adroll_email);
         });
 
         it('should not pass empty email', function() {
@@ -143,6 +144,7 @@ each([1, 2], function(version) {
             adroll_segments: 'order_created',
             user_id: 'id'
           });
+          analytics.calledOnce(window.__adroll.record_user);
         });
 
         it('should include orderId', function() {
@@ -151,6 +153,7 @@ each([1, 2], function(version) {
             adroll_segments: 'order_created',
             order_id: 1
           });
+          analytics.calledOnce(window.__adroll.record_user);
         });
 
         it('should map revenue for normal track events', function() {
@@ -159,6 +162,7 @@ each([1, 2], function(version) {
             adroll_segments: 'ate_habanero_cheese',
             adroll_conversion_value: 17.38
           });
+          analytics.calledOnce(window.__adroll.record_user);
         });
 
         it('should not map revenue if no revenue is found', function() {
@@ -166,6 +170,7 @@ each([1, 2], function(version) {
           analytics.called(window.__adroll.record_user, {
             adroll_segments: 'ate_habanero_cheese'
           });
+          analytics.calledOnce(window.__adroll.record_user);
         });
 
         it('should map revenue to conversion_value', function() {
@@ -174,6 +179,7 @@ each([1, 2], function(version) {
             adroll_segments: 'order_created',
             adroll_conversion_value: 1.99
           });
+          analytics.calledOnce(window.__adroll.record_user);
         });
 
         it('should should send total if no revenue for conversion_value', function() {
@@ -183,6 +189,7 @@ each([1, 2], function(version) {
             adroll_conversion_value: 29.88,
             total: 29.88
           });
+          analytics.calledOnce(window.__adroll.record_user);
         });
 
         it('should map revenue as conversion_value and total as custom prop', function() {
@@ -192,6 +199,7 @@ each([1, 2], function(version) {
             adroll_conversion_value: 2.99,
             total: 17.38
           });
+          analytics.calledOnce(window.__adroll.record_user);
         });
 
         it('should include properties', function() {
@@ -203,6 +211,7 @@ each([1, 2], function(version) {
             other: '1234',
             order_id: '12345'
           });
+          analytics.calledOnce(window.__adroll.record_user);
         });
 
         it('should map price and product id for viewed product', function() {
@@ -212,6 +221,7 @@ each([1, 2], function(version) {
             adroll_conversion_value: 17.38,
             product_id: 'beans'
           });
+          analytics.calledOnce(window.__adroll.record_user);
         });
 
         it('should map price and product id for added product', function() {
@@ -221,6 +231,7 @@ each([1, 2], function(version) {
             adroll_conversion_value: 17.38,
             product_id: 'beans'
           });
+          analytics.calledOnce(window.__adroll.record_user);
         });
       });
     });

--- a/test/common.test.js
+++ b/test/common.test.js
@@ -19,7 +19,9 @@ each([1, 2], function(version) {
         'Viewed Home Page': 'viewed_home_page',
         'Viewed Home Index Page': 'viewed_home_index_page',
         'Completed Order': 'order_created',
-        Teems: 'Ate habanero cheese'
+        'Viewed Product': 'viewed_product',
+        'Added Product': 'added_product',
+        Teems: 'ate_habanero_cheese'
       }
     };
 
@@ -120,7 +122,7 @@ each([1, 2], function(version) {
         it('should pass email', function() {
           analytics.identify('id', { email: 'test@email.com' });
           analytics.equal('test@email.com', window.adroll_email);
-          analytics.calledOnce(window.__adroll.record_adroll_email);
+          analytics.called(window.__adroll.record_adroll_email);
         });
 
         it('should not pass empty email', function() {
@@ -137,15 +139,15 @@ each([1, 2], function(version) {
         it('should include userId', function() {
           analytics.user().identify('id');
           analytics.track('Completed Order', {});
-          analytics.calledOnce(window.__adroll.record_user, {
+          analytics.called(window.__adroll.record_user, {
             adroll_segments: 'order_created',
             user_id: 'id'
           });
         });
 
         it('should include orderId', function() {
-          analytics.track('Completed Order', { id: 1 });
-          analytics.calledOnce(window.__adroll.record_user, {
+          analytics.track('Completed Order', { orderId: 1 });
+          analytics.called(window.__adroll.record_user, {
             adroll_segments: 'order_created',
             order_id: 1
           });
@@ -153,22 +155,22 @@ each([1, 2], function(version) {
 
         it('should map revenue for normal track events', function() {
           analytics.track('Teems', { revenue: 17.38 });
-          analytics.calledOnce(window.__adroll.record_user, {
-            adroll_segments: 'Ate habanero cheese',
+          analytics.called(window.__adroll.record_user, {
+            adroll_segments: 'ate_habanero_cheese',
             adroll_conversion_value: 17.38
           });
         });
 
         it('should not map revenue if no revenue is found', function() {
           analytics.track('Teems');
-          analytics.calledOnce(window.__adroll.record_user, {
-            adroll_segments: 'Ate habanero cheese'
+          analytics.called(window.__adroll.record_user, {
+            adroll_segments: 'ate_habanero_cheese'
           });
         });
 
         it('should map revenue to conversion_value', function() {
           analytics.track('Completed Order', { revenue: 1.99 });
-          analytics.calledOnce(window.__adroll.record_user, {
+          analytics.called(window.__adroll.record_user, {
             adroll_segments: 'order_created',
             adroll_conversion_value: 1.99
           });
@@ -176,15 +178,16 @@ each([1, 2], function(version) {
 
         it('should should send total if no revenue for conversion_value', function() {
           analytics.track('Completed Order', { total: 29.88 });
-          analytics.calledOnce(window.__adroll.record_user, {
+          analytics.called(window.__adroll.record_user, {
             adroll_segments: 'order_created',
-            adroll_conversion_value: 29.88
+            adroll_conversion_value: 29.88,
+            total: 29.88
           });
         });
 
         it('should map revenue as conversion_value and total as custom prop', function() {
           analytics.track('Completed Order', { revenue: 2.99, total: 17.38 });
-          analytics.calledOnce(window.__adroll.record_user, {
+          analytics.called(window.__adroll.record_user, {
             adroll_segments: 'order_created',
             adroll_conversion_value: 2.99,
             total: 17.38
@@ -192,14 +195,31 @@ each([1, 2], function(version) {
         });
 
         it('should include properties', function() {
-          analytics.track('Completed Order', { revenue: 2.99, id: '12345', sku: '43434-21', other: '1234' });
-          analytics.calledOnce(window.__adroll.record_user, {
+          analytics.track('Completed Order', { revenue: 2.99, orderId: '12345', sku: '43434-21', other: '1234' });
+          analytics.called(window.__adroll.record_user, {
             adroll_segments: 'order_created',
             adroll_conversion_value: 2.99,
-            product_id: '12345',
             sku: '43434-21',
             other: '1234',
             order_id: '12345'
+          });
+        });
+
+        it('should map price and product id for viewed product', function() {
+          analytics.track('Viewed Product', { price: 17.38, id: 'beans' });
+          analytics.called(window.__adroll.record_user, {
+            adroll_segments: 'viewed_product',
+            adroll_conversion_value: 17.38,
+            product_id: 'beans'
+          });
+        });
+
+        it('should map price and product id for added product', function() {
+          analytics.track('Added Product', { price: 17.38, id: 'beans' });
+          analytics.called(window.__adroll.record_user, {
+            adroll_segments: 'added_product',
+            adroll_conversion_value: 17.38,
+            product_id: 'beans'
           });
         });
       });

--- a/test/v1.test.js
+++ b/test/v1.test.js
@@ -62,6 +62,7 @@ describe('AdRoll - v1', function() {
           title: window.document.title,
           url: window.location.href
         });
+        analytics.calledOnce(window.__adroll.record_user);
       });
 
       it('should track a named and categorized page page', function() {
@@ -82,6 +83,7 @@ describe('AdRoll - v1', function() {
           title: window.document.title,
           url: window.location.href
         });
+        analytics.calledOnce(window.__adroll.record_user);
       });
 
       it('should track an unnamed page', function() {
@@ -100,6 +102,7 @@ describe('AdRoll - v1', function() {
           title: window.document.title,
           url: window.location.href
         });
+        analytics.calledOnce(window.__adroll.record_user);
       });
     });
 
@@ -113,6 +116,7 @@ describe('AdRoll - v1', function() {
         analytics.called(window.__adroll.record_user, {
           adroll_segments: 'conversion'
         });
+        analytics.calledOnce(window.__adroll.record_user);
       });
 
       it('should convert mapped segment names to snake case', function() {
@@ -121,6 +125,7 @@ describe('AdRoll - v1', function() {
         analytics.called(window.__adroll.record_user, {
           adroll_segments: 'ord_cancel'
         });
+        analytics.calledOnce(window.__adroll.record_user);
       });
 
       it('should send an event when no mapping is found, using the snakized event name as the segment', function() {
@@ -129,6 +134,7 @@ describe('AdRoll - v1', function() {
         analytics.called(window.__adroll.record_user, {
           adroll_segments: 'promotion_clicked'
         });
+        analytics.calledOnce(window.__adroll.record_user);
       });
 
       it('should not send a fallback event when a mapping is found', function() {
@@ -140,6 +146,7 @@ describe('AdRoll - v1', function() {
         analytics.didNotCall(window.__adroll.record_user, {
           adroll_segments: 'order_canceled'
         });
+        analytics.calledOnce(window.__adroll.record_user);
       });
     });
   });

--- a/test/v2.test.js
+++ b/test/v2.test.js
@@ -63,6 +63,7 @@ describe('AdRoll - v2', function() {
           title: window.document.title,
           url: window.location.href
         });
+        analytics.calledOnce(window.__adroll.record_user);
       });
 
       it('should send a mapped named and categorized page', function() {
@@ -83,6 +84,7 @@ describe('AdRoll - v2', function() {
           title: window.document.title,
           url: window.location.href
         });
+        analytics.calledOnce(window.__adroll.record_user);
       });
 
       it('should not send an unmapped page', function() {
@@ -107,6 +109,7 @@ describe('AdRoll - v2', function() {
           adroll_segments: 'f21vVsxY',
           adroll_conversion_value: 17.38
         });
+        analytics.calledOnce(window.__adroll.record_user);
       });
 
       it('should map currency', function() {
@@ -116,6 +119,7 @@ describe('AdRoll - v2', function() {
           adroll_conversion_value: 17.38,
           adroll_currency: 'CAD'
         });
+        analytics.calledOnce(window.__adroll.record_user);
       });
 
       it('should not send an unmapped event', function() {


### PR DESCRIPTION
The tests were previously using `calledOnce` which I found doesn't really test the payload correctly. So changed them all to use `called`. 

Also realized that we should be using `orderId` and `price` for `Completed Order` events and `Viewed/Added Product` events since those are the props that are listed in our spec for those respective events.

I'm also making sure that we send `adroll_conversion_value` regardless of the name of the track event. As long as `properties.revenue` exists, we should send that along!
