### PR TITLE
updating ecommerce syntax to v2 spec

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,7 +95,7 @@ AdRoll.prototype.identify = function(identify) {
 AdRoll.prototype.track = function(track) {
   var events = this.events(track.event());
   var userId = this.analytics.user().id();
-  var data = formulateData(track, { revenue: 'adroll_conversion_value' });
+  var data = formulateData(track, { revenue: 'adroll_conversion_value', currency: 'adroll_currency' });
   // As of April 2015, Adroll no longer accepts segments by name, instead
   // segmenting exclusively by segment ID, which will be present in events map
   // TODO: Deprecate and remove this behavior
@@ -112,13 +112,13 @@ AdRoll.prototype.track = function(track) {
 };
 
 /**
- * Viewed/Added Product
+ * Product Added/Viewed
  *
  * @api public
  * @param {Track} track
  */
 
-AdRoll.prototype.viewedProduct = AdRoll.prototype.addedProduct = function(track) {
+AdRoll.prototype.productAdded = AdRoll.prototype.productViewed = function(track) {
   var events = this.events(track.event());
   var userId = this.analytics.user().id();
   var data = formulateData(track, {
@@ -139,13 +139,13 @@ AdRoll.prototype.viewedProduct = AdRoll.prototype.addedProduct = function(track)
 };
 
 /**
- * Completed Order
+ * Order Completed
  *
  * @api public
  * @param {Track} track
  */
 
-AdRoll.prototype.completedOrder = function(track) {
+AdRoll.prototype.orderCompleted = function(track) {
   var events = this.events(track.event());
   var userId = this.analytics.user().id();
   var data = formulateData(track, {

--- a/test/common.test.js
+++ b/test/common.test.js
@@ -18,9 +18,9 @@ each([1, 2], function(version) {
       events: {
         'Viewed Home Page': 'viewed_home_page',
         'Viewed Home Index Page': 'viewed_home_index_page',
-        'Completed Order': 'order_created',
-        'Viewed Product': 'viewed_product',
-        'Added Product': 'added_product',
+        'Order Completed': 'order_created',
+        'Product Viewed': 'viewed_product',
+        'Product Added': 'added_product',
         Teems: 'ate_habanero_cheese'
       }
     };
@@ -139,7 +139,7 @@ each([1, 2], function(version) {
 
         it('should include userId', function() {
           analytics.user().identify('id');
-          analytics.track('Completed Order', {});
+          analytics.track('Order Completed', {});
           analytics.called(window.__adroll.record_user, {
             adroll_segments: 'order_created',
             user_id: 'id'
@@ -148,7 +148,7 @@ each([1, 2], function(version) {
         });
 
         it('should include orderId', function() {
-          analytics.track('Completed Order', { orderId: 1 });
+          analytics.track('Order Completed', { orderId: 1 });
           analytics.called(window.__adroll.record_user, {
             adroll_segments: 'order_created',
             order_id: 1
@@ -174,7 +174,7 @@ each([1, 2], function(version) {
         });
 
         it('should map revenue to conversion_value', function() {
-          analytics.track('Completed Order', { revenue: 1.99 });
+          analytics.track('Order Completed', { revenue: 1.99 });
           analytics.called(window.__adroll.record_user, {
             adroll_segments: 'order_created',
             adroll_conversion_value: 1.99
@@ -183,7 +183,7 @@ each([1, 2], function(version) {
         });
 
         it('should should send total if no revenue for conversion_value', function() {
-          analytics.track('Completed Order', { total: 29.88 });
+          analytics.track('Order Completed', { total: 29.88 });
           analytics.called(window.__adroll.record_user, {
             adroll_segments: 'order_created',
             adroll_conversion_value: 29.88,
@@ -193,7 +193,7 @@ each([1, 2], function(version) {
         });
 
         it('should map revenue as conversion_value and total as custom prop', function() {
-          analytics.track('Completed Order', { revenue: 2.99, total: 17.38 });
+          analytics.track('Order Completed', { revenue: 2.99, total: 17.38 });
           analytics.called(window.__adroll.record_user, {
             adroll_segments: 'order_created',
             adroll_conversion_value: 2.99,
@@ -203,7 +203,7 @@ each([1, 2], function(version) {
         });
 
         it('should include properties', function() {
-          analytics.track('Completed Order', { revenue: 2.99, orderId: '12345', sku: '43434-21', other: '1234' });
+          analytics.track('Order Completed', { revenue: 2.99, orderId: '12345', sku: '43434-21', other: '1234' });
           analytics.called(window.__adroll.record_user, {
             adroll_segments: 'order_created',
             adroll_conversion_value: 2.99,
@@ -214,8 +214,8 @@ each([1, 2], function(version) {
           analytics.calledOnce(window.__adroll.record_user);
         });
 
-        it('should map price and product id for viewed product', function() {
-          analytics.track('Viewed Product', { price: 17.38, id: 'beans' });
+        it('should map price and product id for Product Viewed', function() {
+          analytics.track('Product Viewed', { price: 17.38, id: 'beans' });
           analytics.called(window.__adroll.record_user, {
             adroll_segments: 'viewed_product',
             adroll_conversion_value: 17.38,
@@ -224,8 +224,8 @@ each([1, 2], function(version) {
           analytics.calledOnce(window.__adroll.record_user);
         });
 
-        it('should map price and product id for added product', function() {
-          analytics.track('Added Product', { price: 17.38, id: 'beans' });
+        it('should map price and product id for Product Added', function() {
+          analytics.track('Product Added', { price: 17.38, id: 'beans' });
           analytics.called(window.__adroll.record_user, {
             adroll_segments: 'added_product',
             adroll_conversion_value: 17.38,

--- a/test/v2.test.js
+++ b/test/v2.test.js
@@ -15,7 +15,7 @@ describe('AdRoll - v2', function() {
     events: {
       'Viewed Home Page': 'zi2b9e01',
       'Viewed Home Index Page': 'Jxp3fGpw',
-      'Completed Order': 'f21vVsxY'
+      'Order Completed': 'f21vVsxY'
     }
   };
 
@@ -104,7 +104,7 @@ describe('AdRoll - v2', function() {
       });
 
       it('should send a mapped event', function() {
-        analytics.track('Completed Order', { revenue: 17.38 });
+        analytics.track('Order Completed', { revenue: 17.38 });
         analytics.called(window.__adroll.record_user, {
           adroll_segments: 'f21vVsxY',
           adroll_conversion_value: 17.38
@@ -113,7 +113,7 @@ describe('AdRoll - v2', function() {
       });
 
       it('should map currency', function() {
-        analytics.track('Completed Order', { revenue: 17.38, currency: 'CAD' });
+        analytics.track('Order Completed', { revenue: 17.38, currency: 'CAD' });
         analytics.called(window.__adroll.record_user, {
           adroll_segments: 'f21vVsxY',
           adroll_conversion_value: 17.38,


### PR DESCRIPTION
This PR changes the ecommerce V1 syntax `Action + Object` to the new V2 syntax, `Object + Action`.

This PR will be waiting on a few blockers, a refactor of the [Analytics-Events repo](https://github.com/segmentio/analytics-events) to be more concise and readable as we add more events to our spec and for similar changes to be made to all other integrations currently using V1 syntax.

Tests are failing because it isn't properly aliasing against the new spec'd events. These tests will need to pass, dependent on a new version of Analytics Events and Analytics.js-Private before being merged.
